### PR TITLE
Pound signs have no rizz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryzz"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
@@ -15,7 +15,7 @@ members = [
 ]
 
 [dependencies]
-ryzz_macros = { path = "ryzz_macros", version = "0.1.0" }
+ryzz_macros = { path = "ryzz_macros", version = "0.2.0" }
 rusqlite = { version = "0.29.0", features = ["bundled", "serde_json"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = { version = "1.0.106" }

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ post.body = "post".into();
 let post: Post = db
     .update(posts)
     .set(post)?
-    .r#where(and(eq(posts.id, 1), eq(posts.title, Value::Null)))
+    .where_(and(eq(posts.id, 1), eq(posts.title, Value::Null)))
     .returning()
     .await?;
 
 // delete from posts where id = ? returning *
 let post: Post = db
     .delete_from(posts)
-    .r#where(eq(posts.id, 1))
+    .where_(eq(posts.id, 1))
     .returning()
     .await?;
 ```

--- a/ryzz_macros/Cargo.toml
+++ b/ryzz_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryzz_macros"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/ryzz_macros/src/lib.rs
+++ b/ryzz_macros/src/lib.rs
@@ -202,7 +202,7 @@ fn table_macro(args: Args, mut row_struct: ItemStruct) -> Result<TokenStream2> {
                     .select(())
                     .from(sqlite_schema)
                     .left_outer_join(pti, ryzz::ne(pti.name, sqlite_schema.name))
-                    .r#where(ryzz::and(ryzz::eq(sqlite_schema.r#type, "table".to_owned()), ryzz::eq(sqlite_schema.name, table.table_name().to_owned())))
+                    .where_(ryzz::and(ryzz::eq(sqlite_schema.r#type, "table".to_owned()), ryzz::eq(sqlite_schema.name, table.table_name().to_owned())))
                     .all::<ryzz::TableInfoRow>()
                     .await?
                     .into_iter()

--- a/ryzz_macros/src/lib.rs
+++ b/ryzz_macros/src/lib.rs
@@ -547,7 +547,7 @@ fn r#default(field: &RyzzField) -> Option<String> {
         .filter_map(|attr| attr.default_value.as_ref())
         .last()
     {
-        Some(r#default) => Some(format!("default ({})", r#default.value())),
+        Some(r#default) => Some(format!("default {}", r#default.value())),
         None => None,
     }
 }

--- a/ryzz_macros/src/lib.rs
+++ b/ryzz_macros/src/lib.rs
@@ -359,7 +359,7 @@ impl Parse for RyzzAttr {
                                 "table" => {
                                     ryzz_attr.table_name = Some(lit_str.clone());
                                 }
-                                "r#default" => {
+                                "r#default" | "default_" => {
                                     ryzz_attr.default_value = Some(lit_str.clone());
                                 }
                                 "fk" => {
@@ -368,7 +368,7 @@ impl Parse for RyzzAttr {
                                 "name" => {
                                     ryzz_attr.name = Some(lit_str.clone());
                                 }
-                                "r#as" => {
+                                "r#as" | "as_" => {
                                     ryzz_attr.r#as = Some(lit_str.clone());
                                 }
                                 _ => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1046,7 +1046,22 @@ pub fn like(left: impl ToColumn, right: impl ToValueColumn) -> Sql {
     }
 }
 
+#[deprecated(since = "0.1.0", note = "please use `in_` instead")]
 pub fn r#in(left: impl ToColumn, right: Vec<impl ToValueColumn>) -> Sql {
+    Sql {
+        clause: format!(
+            "{} in ({})",
+            left.to_column(),
+            right.iter().map(|_| "?").collect::<Vec<&str>>().join(",")
+        ),
+        params: right
+            .into_iter()
+            .filter_map(|val| val.to_value())
+            .collect::<Vec<Value>>(),
+    }
+}
+
+pub fn in_(left: impl ToColumn, right: Vec<impl ToValueColumn>) -> Sql {
     Sql {
         clause: format!(
             "{} in ({})",


### PR DESCRIPTION
This PR:

Deprecates:

- `r#where`
- `r#in`

Adds:

- `where_`
- `in_`
- `default_`
- `as_`
- `default_values` fn to `Query`

Changes:

- the default macro attribute no longer wraps default values in parens, you gotta bring your own parens