### PR TITLE
Return self from values and set fns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryzz"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ let post = Post {
 // insert into posts (id, body) values (?, ?) returning *
 let mut post: Post = db
     .insert(posts)
-    .values(post)?
+    .values(post)
     .returning()
     .await?;
 
@@ -60,7 +60,7 @@ post.body = "post".into();
 // update posts set body = ?, id = ? where id = ? returning *
 let post: Post = db
     .update(posts)
-    .set(post)?
+    .set(post)
     .where_(and(eq(posts.id, 1), eq(posts.title, Value::Null)))
     .returning()
     .await?;


### PR DESCRIPTION
This is unfortunately a breaking change, but it's so early I figured it's better to do it now than later.

This removes the returning `Result` from `values` and `set`:

```rust
// before
let query = db.update(posts).set(post)?;

// after
let query = db.update(posts).set(post);
```

```rust
// before
let query = db.insert(posts).values(post)?;

// after
let query = db.insert(posts).values(post);
```