### PR TITLE
Add From conversion for Connection and Database

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1196,6 +1196,12 @@ pub struct Database {
     pub connection: tokio_rusqlite::Connection,
 }
 
+impl From<tokio_rusqlite::Connection> for Database {
+    fn from(connection: tokio_rusqlite::Connection) -> Self {
+        Self { connection }
+    }
+}
+
 impl Database {
     pub async fn new(path: &str) -> Result<Self, Error> {
         Ok(Self {


### PR DESCRIPTION
This PR implements the From trait for Database enabling conversion from a Connection struct.